### PR TITLE
feat(): estimate deploy and upgrade proxy

### DIFF
--- a/bin/act-deploy
+++ b/bin/act-deploy
@@ -93,19 +93,29 @@ async function onproxy(argv) {
 
   try {
     const opts = { contentDid: did, password, version, keyringOpts }
+    const estimateOpts = Object.assign({}, opts, { estimate: true })
     if (!upgrade) {
       info(`Deploying new proxy for ${did} at version ${version}...`)
-      // act deploy proxy 7278cc43820a31d6907b8ed358b05bcc03c6a9bf6bbaefdcb1d7baeff33de0a6 2 -s test-node -n resolver -k /Users/ericjiang/.ara/keyrings/aws-test.pub -D
-      const address = await registry.deployProxy(opts)
-      info(`Proxy deployed at address ${address} for ${did}.`)
+      // act deploy proxy 6684a1af92dea872c2a0b2e53fa0d610c806895c75a234bcdf92efcf86ee9a 1
+      const cost = await registry.deployProxy(estimateOpts)
+      const { answer } = await promptCostConfirmation(cost)
+      if (answer) {
+        const address = await registry.deployProxy(opts)
+        info(`Proxy deployed at address ${address} for ${did}.`)
+      }
     } else {
       info(`Upgrading proxy for ${did} to version ${version}...`)
-      // act deploy proxy -u f5153d78579dcc7d4ed57acd3cc789a69fe3780314432443a471d1e2dea577b8 2 -s test-node -n resolver -k /Users/ericjiang/.ara/keyrings/aws-test.pub -D
-      const upgraded = await registry.upgradeProxy(opts)
-      if (upgraded) {
-        info(`Proxy successfully upgraded to version ${version}.`)
+      // act deploy proxy -u f5153d78579dcc7d4ed57acd3cc789a69fe3780314432443a471d1e2dea577b8
+      const cost = await registry.upgradeProxy(estimateOpts)
+      const { answer } = await promptCostConfirmation(cost)
+      if (answer) {
+        const upgraded = await registry.upgradeProxy(opts)
+        if (upgraded) {
+          info(`Proxy successfully upgraded to version ${version}.`)
+        }
       }
     }
+
   } catch (err) {
     onfatal(err)
   }
@@ -149,6 +159,16 @@ async function promptForPassword() {
     "complete this action.\n" +
     "Passphrase:"
   }]) 
+}
+
+async function promptCostConfirmation(cost) {
+  return inquirer.prompt({
+    type: 'confirm',
+    name: 'answer',
+    message:
+    `This operation will cost ${cost} ETH. Are you sure you
+    want to proceed?`
+  })
 }
 
 function onfatal(err) {

--- a/registry.js
+++ b/registry.js
@@ -96,15 +96,18 @@ async function upgradeProxy(opts) {
   if (!opts || 'object' !== typeof opts) {
     throw new TypeError('Expecting opts object.')
   } else if ('string' !== typeof opts.contentDid || !opts.contentDid) {
-    throw TypeError('Expecting non-empty content DID')
+    throw new TypeError('Expecting non-empty content DID')
   } else if (null == opts.password || 'string' !== typeof opts.password || !opts.password) {
-    throw TypeError('Expecting non-empty password')
+    throw new TypeError('Expecting non-empty password')
   } else if (('string' !== typeof opts.version && 'number' !== typeof opts.version) || !opts.version) {
-    throw TypeError('Expecting non-empty version string or number')
+    throw new TypeError('Expecting non-empty version string or number')
+  } else if (opts.estimate && 'boolean' !== typeof opts.estimate) {
+    throw new TypeError('Expecting estimate to be of type boolean')
   }
 
   let { version } = opts
   const { contentDid, password, keyringOpts } = opts
+  const estimate = opts.estimate || false
 
   if ('number' === typeof version) {
     version = version.toString()
@@ -139,6 +142,10 @@ async function upgradeProxy(opts) {
         ]
       }
     })
+
+    if (estimate) {
+      return tx.estimateCost(transaction)
+    }
 
     const registry = await contract.get(abi, REGISTRY_ADDRESS)
     // listen to ProxyUpgraded event for proxy address
@@ -179,12 +186,15 @@ async function deployProxy(opts) {
   if (!opts || 'object' !== typeof opts) {
     throw new TypeError('Expecting opts object.')
   } else if (null == opts.contentDid || 'string' !== typeof opts.contentDid || !opts.contentDid) {
-    throw TypeError('Expecting non-empty content DID')
+    throw new TypeError('Expecting non-empty content DID')
   } else if (null == opts.password || 'string' !== typeof opts.password || !opts.password) {
-    throw TypeError('Expecting non-empty password')
+    throw new TypeError('Expecting non-empty password')
+  } else if (opts.estimate && 'boolean' !== typeof opts.estimate) {
+    throw new TypeError('Expecting estimate to be of type boolean')
   }
 
   const { password, contentDid, keyringOpts } = opts
+  const estimate = opts.estimate || false
 
   let version = opts.version || STANDARD_VERSION
   if ('number' === typeof version) {
@@ -226,6 +236,10 @@ async function deployProxy(opts) {
         ]
       }
     })
+
+    if (estimate) {
+      return tx.estimateCost(transaction)
+    }
 
     // listen to ProxyDeployed event for proxy address
     const registry = await contract.get(abi, REGISTRY_ADDRESS)


### PR DESCRIPTION
This will be used in `ara-filesystem` so the proxy doesn't have to be deployed to estimate the gas cost of a commit.