### PR TITLE
chore(.gitattributes): Set .sol to Solidity syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Fixes # Solidity syntax

## Proposed Changes

  - Add .gitattributes

see https://medium.com/@danielque/psa-how-to-fix-githubs-syntax-highlighting-for-solidity-4e9867c540b6

* highlighting appears after .sol file is saved again